### PR TITLE
Fix erros due to microxrcedds_agent package

### DIFF
--- a/micro_ros_setup/config/agent_uros_packages.repos
+++ b/micro_ros_setup/config/agent_uros_packages.repos
@@ -6,8 +6,3 @@ repositories:
     url: https://github.com/microROS/micro-ROS-Agent.git
     version: Crystal
 
-# eProsima
-  eProsima/Micro-XRCE-DDS-Agent:
-    type: git
-    url: https://github.com/eProsima/Micro-XRCE-DDS-Agent.git
-    version: v1.0.3

--- a/micro_ros_setup/config/agent_uros_packages.repos
+++ b/micro_ros_setup/config/agent_uros_packages.repos
@@ -4,4 +4,4 @@ repositories:
   uros/uROS_agent:
     type: git
     url: https://github.com/microROS/micro-ROS-Agent.git
-    version: fix/crystal-package-list
+    version: fix/rename_package

--- a/micro_ros_setup/config/agent_uros_packages.repos
+++ b/micro_ros_setup/config/agent_uros_packages.repos
@@ -5,3 +5,9 @@ repositories:
     type: git
     url: https://github.com/microROS/micro-ROS-Agent.git
     version: fix/rename_package
+
+# eProsima
+  eProsima/Micro-XRCE-DDS-Agent:
+    type: git
+    url: https://github.com/eProsima/Micro-XRCE-DDS-Agent.git
+    version: v1.0.3

--- a/micro_ros_setup/config/agent_uros_packages.repos
+++ b/micro_ros_setup/config/agent_uros_packages.repos
@@ -4,7 +4,7 @@ repositories:
   uros/uROS_agent:
     type: git
     url: https://github.com/microROS/micro-ROS-Agent.git
-    version: fix/rename_package
+    version: Crystal
 
 # eProsima
   eProsima/Micro-XRCE-DDS-Agent:

--- a/micro_ros_setup/scripts/create_agent_ws.sh
+++ b/micro_ros_setup/scripts/create_agent_ws.sh
@@ -21,3 +21,5 @@ cp $(ros2 pkg prefix micro_ros_setup)/config/agent-colcon.meta $TARGETDIR/colcon
 
 rosdep install --from-paths $TARGETDIR -i $TARGETDIR -y \
   --skip-keys="microxrcedds_agent rosidl_typesupport_opensplice_c rosidl_typesupport_opensplice_cpp rmw_opensplice_cpp rmw_connext_cpp rosidl_typesupport_connext_c rosidl_typesupport_connext_cpp"
+sudo apt-get install -y ros-crystal-micro-xrce-dds-agent
+

--- a/micro_ros_setup/scripts/create_agent_ws.sh
+++ b/micro_ros_setup/scripts/create_agent_ws.sh
@@ -20,4 +20,4 @@ ros2 run micro_ros_setup create_ws.sh $TARGETDIR agent_ros2_packages.txt agent_u
 cp $(ros2 pkg prefix micro_ros_setup)/config/agent-colcon.meta $TARGETDIR/colcon.meta
 
 rosdep install --from-paths $TARGETDIR -i $TARGETDIR -y \
-  --skip-keys="rosidl_typesupport_opensplice_c rosidl_typesupport_opensplice_cpp rmw_opensplice_cpp rmw_connext_cpp rosidl_typesupport_connext_c rosidl_typesupport_connext_cpp"
+  --skip-keys="microxrcedds_agent rosidl_typesupport_opensplice_c rosidl_typesupport_opensplice_cpp rmw_opensplice_cpp rmw_connext_cpp rosidl_typesupport_connext_c rosidl_typesupport_connext_cpp"


### PR DESCRIPTION
I am not 100% happy with this solution as I think microxrcedds_agent should come from rosdep install call.
Temporary I have changed to be it from a repository within .repos for the agent.
We should update once microxrcedds_agent Debian package makes it to the main.