### PR TITLE
Roll back the microxrcedds_agent workaround

### DIFF
--- a/micro_ros_setup/scripts/create_agent_ws.sh
+++ b/micro_ros_setup/scripts/create_agent_ws.sh
@@ -20,6 +20,4 @@ ros2 run micro_ros_setup create_ws.sh $TARGETDIR agent_ros2_packages.txt agent_u
 cp $(ros2 pkg prefix micro_ros_setup)/config/agent-colcon.meta $TARGETDIR/colcon.meta
 
 rosdep install --from-paths $TARGETDIR -i $TARGETDIR -y \
-  --skip-keys="microxrcedds_agent rosidl_typesupport_opensplice_c rosidl_typesupport_opensplice_cpp rmw_opensplice_cpp rmw_connext_cpp rosidl_typesupport_connext_c rosidl_typesupport_connext_cpp"
-sudo apt-get install -y ros-crystal-micro-xrce-dds-agent
-
+  --skip-keys="rosidl_typesupport_opensplice_c rosidl_typesupport_opensplice_cpp rmw_opensplice_cpp rmw_connext_cpp rosidl_typesupport_connext_c rosidl_typesupport_connext_cpp"


### PR DESCRIPTION
As from today microxrcedds-agent could be resolved with rosdep:
https://discourse.ros.org/t/new-packages-for-ros-2-crystal-2019-09-19/10737
