### PR TITLE
Add middleware configuration in colcon metas file.

### DIFF
--- a/micro_ros_setup/config/nuttx/generic/client-colcon.meta
+++ b/micro_ros_setup/config/nuttx/generic/client-colcon.meta
@@ -1,5 +1,13 @@
 { "names": {
   "rcutils": { "cmake-args": [ "-DENABLE_TESTING=OFF" ], },
-  "microxrcedds_client": { "cmake-args": [ "-DUCLIENT_ISOLATED_INSTALL=OFF", "-DUCLIENT_PIC=OFF", "-DUCLIENT_SUPERBUILD=OFF" ], },
+  "microxrcedds_client": { "cmake-args": [ "-DUCLIENT_ISOLATED_INSTALL=OFF", "-DUCLIENT_PIC=OFF", "-DUCLIENT_SUPERBUILD=OFF" ] },
+  "rmw_microxrcedds": { "cmake-args": [
+    "-DRMW_UXRCE_MAX_NODES=1",
+    "-DRMW_UXRCE_MAX_PUBLISHERS_X_NODE=2",
+    "-DRMW_UXRCE_MAX_SUBSCRIPTIONS_X_NODE=1",
+    "-DRMW_UXRCE_MAX_SERVICES_X_NODE=1",
+    "-DRMW_UXRCE_MAX_CLIENTS_X_NODE=1",
+    "-DRMW_UXRCE_MAX_HISTORY=4",
+    "-DRMW_UXRCE_XML_BUFFER_LENGTH=400"] }
   }
 }


### PR DESCRIPTION
Solves issues building NuttX due to static memory usage too high with default configuration values.