### PR TITLE
Fix multiple typesupport error

### DIFF
--- a/micro_ros_setup/config/freertos/crazyflie21/client_uros_packages.repos
+++ b/micro_ros_setup/config/freertos/crazyflie21/client_uros_packages.repos
@@ -26,10 +26,6 @@ repositories:
     type: git
     url: https://github.com/micro-ROS/rosidl_typesupport_microxrcedds.git
     version: dashing
-  uros/rosidl_typesupport:
-    type: git
-    url: https://github.com/micro-ROS/rosidl_typesupport.git
-    version: dashing
 
 # interim, until crosscompile fix is available in dashing branch
   ros2/tinydir_vendor:

--- a/micro_ros_setup/config/freertos/olimex-stm32-e407/client_uros_packages.repos
+++ b/micro_ros_setup/config/freertos/olimex-stm32-e407/client_uros_packages.repos
@@ -26,10 +26,7 @@ repositories:
     type: git
     url: https://github.com/micro-ROS/rosidl_typesupport_microxrcedds.git
     version: feature/dashing_migration
-  uros/rosidl_typesupport:
-    type: git
-    url: https://github.com/micro-ROS/rosidl_typesupport.git
-    version: dashing
+
 # Remove this when it returns to ros2.repos
   ros2/tinydir_vendor:
     type: git

--- a/micro_ros_setup/config/nuttx/generic/client_uros_packages.repos
+++ b/micro_ros_setup/config/nuttx/generic/client_uros_packages.repos
@@ -26,10 +26,6 @@ repositories:
     type: git
     url: https://github.com/micro-ROS/rcutils.git
     version: dashing
-  uros/rosidl_typesupport:
-    type: git
-    url: https://github.com/micro-ROS/rosidl_typesupport.git
-    version: dashing
   drive_base:
     type: git
     url: https://github.com/micro-ROS/drive_base.git


### PR DESCRIPTION
This pull request fixes issue #66.
The `ros2/rosidl_typesupport` upstream contains the fix in `uros/rosidl_typesupport`.