### PR TITLE
Improve CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,8 +101,9 @@ jobs:
         run: |
           . /opt/ros/$ROS_DISTRO/setup.sh
           . install/local_setup.sh
+          apt-get update
           ros2 run micro_ros_setup create_host_client_ws.sh
-          colcon build --merge-install --metas src
+          colcon build --merge-install --metas src --packages-skip rclc micro_ros_demos_rclc rclc_examples
 
   client_firmware:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
           - rtos: freertos
             platform: olimex-stm32-e407
             configuration: serial
-            files: 'firmware/olimex_e407_extensions/build/micro-ROS.bin,
+            files: 'firmware/olimex_e407_extensions/build/micro-ROS.bin'
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,9 +104,8 @@ jobs:
         run: |
           . /opt/ros/dashing/setup.sh
           . install/local_setup.sh
-          ros2
-          ros2 run micro_ros_setup create_host_client_ws.sh
           apt-get update
+          ros2 run micro_ros_setup create_host_client_ws.sh
           colcon build --merge-install --metas src --packages-skip rclc micro_ros_demos_rclc rclc_examples
           
       # Check if the file exist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,6 @@ jobs:
         run: |
           . /opt/ros/dashing/setup.sh
           . install/local_setup.sh
-          apt-get update
           ros2 run micro_ros_setup create_host_client_ws.sh
           colcon build --merge-install --metas src --packages-skip rclc micro_ros_demos_rclc rclc_examples
           

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,8 +105,8 @@ jobs:
           . /opt/ros/dashing/setup.sh
           . install/local_setup.sh
           apt-get update
-          ros2 run micro_ros_setup create_host_client_ws.sh
-          colcon build --merge-install --metas src --packages-skip rclc micro_ros_demos_rclc rclc_examples
+          ros2 run micro_ros_setup create_firmware_ws.sh host
+          colcon build --merge-install --metas src - --packages-skip rclc micro_ros_demos_rclc rclc_examples
           
       # Check if the file exist
       - name: Test file installation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,7 @@ jobs:
             files: 'firmware/crazyflie_microros_extensions/cf2.elf'
           - rtos: freertos
             platform: olimex-stm32-e407
+            configuration: serial
             files: 'firmware/olimex_e407_extensions/build/micro-ROS.elf,
                     firmware/olimex_e407_extensions/build/micro-ROS.bin'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,11 +100,11 @@ jobs:
           
       - name: Source required files
         run: |
-          . /opt/ros/dashing/setup.sh
+          . /opt/ros/$ROS_DISTRO/setup.sh
           . install/local_setup.sh
           apt-get update
           ros2 run micro_ros_setup create_firmware_ws.sh host
-          colcon build --merge-install --metas src - --packages-skip rclc micro_ros_demos_rclc rclc_examples
+          colcon build --metas src --packages-skip rclc micro_ros_demos_rclc rclc_examples
           
       # Check if the file exist
       - name: Test file installation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,6 @@ jobs:
     runs-on: ubuntu-latest
     container: microros/base:${{github.base_ref}}
     needs: micro_ros_build
-    # Temporary disable host build while fixing it
-    if: false
 
     steps:
       - uses: actions/checkout@v2
@@ -99,33 +97,28 @@ jobs:
           chmod +x -R install/lib/micro_ros_setup
           chmod +x install/config/host/generic/*.sh
 
+      # TODO: By now skip the RCLC packages, due to compilation errors on the CI docker.
       - name: Create ws and build
         run: |
           . /opt/ros/$ROS_DISTRO/setup.sh
           . install/local_setup.sh
           ros2 run micro_ros_setup create_host_client_ws.sh
-          colcon build --merge-install --metas src
+          colcon build --merge-install --metas src --packages-skip rclc micro_ros_demos_rclc rclc_examples
 
-      - name: Test installation
-        uses: BorjaOuterelo/test-file-system-action@v0.0.1
-        with:
-          path: 'install/lib'
-          files: 'complex_msg_publisher_c/complex_msg_publisher_c,
-                  complex_msg_publisher_cpp/complex_msg_publisher_cpp,
-                  complex_msg_subscriber_c/complex_msg_subscriber_c,
-                  complex_msg_subscriber_cpp/complex_msg_subscriber_cpp,
-                  int32_publisher_c/int32_publisher_c,
-                  int32_publisher_cpp/int32_publisher_cpp,
-                  int32_subscriber_c/int32_subscriber_c,
-                  int32_subscriber_cpp/int32_subscriber_cpp,
-                  rad0_actuator_c/rad0_actuator_c,
-                  rad0_altitude_sensor_c/rad0_altitude_sensor_c,
-                  rad0_control_cpp/rad0_control_cpp,
-                  rad0_display_c/rad0_display_c,
-                  string_publisher_c/string_publisher_c,
-                  string_publisher_cpp/string_publisher_cpp,
-                  string_subscriber_c/string_subscriber_c,
-                  string_subscriber_cpp/string_subscriber_cpp'
+      # Check if the files exist
+      - name: Test file installation
+        run: |
+          (test -f install/lib/micro_ros_demos_rcl/int32_publisher/int32_publisher  && true) || false
+          (test -f install/lib/micro_ros_demos_rcl/int32_subscriber/int32_subscriber  && true) || false
+          (test -f install/lib/micro_ros_demos_rcl/int32_publisher_subscriber/int32_publisher_subscriber  && true) || false
+          (test -f install/lib/micro_ros_demos_rcl/int32_multinode/int32_multinode  && true) || false
+          (test -f install/lib/micro_ros_demos_rcl/guard_condition/guard_condition  && true) || false
+          (test -f install/lib/micro_ros_demos_rcl/fibonacci_action_server/fibonacci_action_server  && true) || false
+          (test -f install/lib/micro_ros_demos_rcl/fibonacci_action_client/fibonacci_action_client  && true) || false
+          (test -f install/lib/micro_ros_demos_rcl/configured_subscriber/configured_subscriber  && true) || false
+          (test -f install/lib/micro_ros_demos_rcl/configured_publisher/configured_publisher  && true) || false
+          (test -f install/lib/micro_ros_demos_rcl/addtwoints_server/addtwoints_server  && true) || false
+          (test -f install/lib/micro_ros_demos_rcl/addtwoints_client/addtwoints_client  && true) || false
 
   client_firmware:
     runs-on: ubuntu-latest
@@ -157,8 +150,7 @@ jobs:
           - rtos: freertos
             platform: olimex-stm32-e407
             configuration: serial
-            files: 'firmware/olimex_e407_extensions/build/micro-ROS.elf,
-                    firmware/olimex_e407_extensions/build/micro-ROS.bin'
+            files: 'firmware/olimex_e407_extensions/build/micro-ROS.bin,
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,9 @@ jobs:
         run: |
           . /opt/ros/dashing/setup.sh
           . install/local_setup.sh
+          ros2
           ros2 run micro_ros_setup create_host_client_ws.sh
+          apt-get update
           colcon build --merge-install --metas src --packages-skip rclc micro_ros_demos_rclc rclc_examples
           
       # Check if the file exist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,7 @@ jobs:
         run: |
           . /opt/ros/$ROS_DISTRO/setup.sh
           . install/local_setup.sh
+          apt-get update
           ros2 run micro_ros_setup create_firmware_ws.sh ${{ matrix.rtos }} ${{ matrix.platform }}
           ros2 run micro_ros_setup configure_firmware.sh ${{ matrix.configuration }}
           ros2 run micro_ros_setup build_firmware.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,8 +135,7 @@ jobs:
           - rtos: freertos
             platform: olimex-stm32-e407
             configuration: serial
-            files: 'firmware/olimex_e407_extensions/build/micro-ROS.elf,
-                    firmware/olimex_e407_extensions/build/micro-ROS.bin'
+            files: 'firmware/olimex_e407_extensions/build/micro-ROS.elf,firmware/olimex_e407_extensions/build/micro-ROS.bin'
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
     branches:
-    - improve_ci
+    - feature/improve_ci
 
 jobs:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,22 @@ jobs:
           apt-get update
           ros2 run micro_ros_setup create_host_client_ws.sh
           colcon build --merge-install --metas src --packages-skip rclc micro_ros_demos_rclc rclc_examples
-
+          
+      # Check if the file exist
+      - name: Test file installation
+        run: |
+          (test -f install/lib/micro_ros_demos_rcl/int32_publisher/int32_publisher  && true) || false
+          (test -f install/lib/micro_ros_demos_rcl/int32_subscriber/int32_subscriber  && true) || false
+          (test -f install/lib/micro_ros_demos_rcl/int32_publisher_subscriber/int32_publisher_subscriber  && true) || false
+          (test -f install/lib/micro_ros_demos_rcl/int32_multinode/int32_multinode  && true) || false
+          (test -f install/lib/micro_ros_demos_rcl/guard_condition/guard_condition  && true) || false
+          (test -f install/lib/micro_ros_demos_rcl/fibonacci_action_server/fibonacci_action_server  && true) || false
+          (test -f install/lib/micro_ros_demos_rcl/fibonacci_action_client/fibonacci_action_client  && true) || false
+          (test -f install/lib/micro_ros_demos_rcl/configured_subscriber/configured_subscriber  && true) || false
+          (test -f install/lib/micro_ros_demos_rcl/configured_publisher/configured_publisher  && true) || false
+          (test -f install/lib/micro_ros_demos_rcl/addtwoints_server/addtwoints_server  && true) || false
+          (test -f install/lib/micro_ros_demos_rcl/addtwoints_client/addtwoints_client  && true) || false
+          
   client_firmware:
     runs-on: ubuntu-latest
     container: microros/ci:${{github.base_ref}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 on:
-  pull_request:
+  push:
     branches:
     - feature/improve_ci
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 on:
-  push:
+  pull:
     branches:
     - improve_ci
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 on:
-  pull:
+  pull_request:
     branches:
     - improve_ci
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 on:
-  pull_request:
+  push:
     branches:
     - improve_ci
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,19 +106,19 @@ jobs:
           colcon build --merge-install --metas src --packages-skip rclc micro_ros_demos_rclc rclc_examples
 
       # Check if the files exist
-      - name: Test file installation
-        run: |
-          (test -f install/lib/micro_ros_demos_rcl/int32_publisher/int32_publisher  && true) || false
-          (test -f install/lib/micro_ros_demos_rcl/int32_subscriber/int32_subscriber  && true) || false
-          (test -f install/lib/micro_ros_demos_rcl/int32_publisher_subscriber/int32_publisher_subscriber  && true) || false
-          (test -f install/lib/micro_ros_demos_rcl/int32_multinode/int32_multinode  && true) || false
-          (test -f install/lib/micro_ros_demos_rcl/guard_condition/guard_condition  && true) || false
-          (test -f install/lib/micro_ros_demos_rcl/fibonacci_action_server/fibonacci_action_server  && true) || false
-          (test -f install/lib/micro_ros_demos_rcl/fibonacci_action_client/fibonacci_action_client  && true) || false
-          (test -f install/lib/micro_ros_demos_rcl/configured_subscriber/configured_subscriber  && true) || false
-          (test -f install/lib/micro_ros_demos_rcl/configured_publisher/configured_publisher  && true) || false
-          (test -f install/lib/micro_ros_demos_rcl/addtwoints_server/addtwoints_server  && true) || false
-          (test -f install/lib/micro_ros_demos_rcl/addtwoints_client/addtwoints_client  && true) || false
+      #- name: Test file installation
+      #  run: |
+      #    (test -f install/lib/micro_ros_demos_rcl/int32_publisher/int32_publisher  && true) || false
+      #    (test -f install/lib/micro_ros_demos_rcl/int32_subscriber/int32_subscriber  && true) || false
+      #    (test -f install/lib/micro_ros_demos_rcl/int32_publisher_subscriber/int32_publisher_subscriber  && true) || false
+      #    (test -f install/lib/micro_ros_demos_rcl/int32_multinode/int32_multinode  && true) || false
+      #    (test -f install/lib/micro_ros_demos_rcl/guard_condition/guard_condition  && true) || false
+      #    (test -f install/lib/micro_ros_demos_rcl/fibonacci_action_server/fibonacci_action_server  && true) || false
+      #    (test -f install/lib/micro_ros_demos_rcl/fibonacci_action_client/fibonacci_action_client  && true) || false
+      #    (test -f install/lib/micro_ros_demos_rcl/configured_subscriber/configured_subscriber  && true) || false
+      #    (test -f install/lib/micro_ros_demos_rcl/configured_publisher/configured_publisher  && true) || false
+      #    (test -f install/lib/micro_ros_demos_rcl/addtwoints_server/addtwoints_server  && true) || false
+      #    (test -f install/lib/micro_ros_demos_rcl/addtwoints_client/addtwoints_client  && true) || false
 
   client_firmware:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
 
   client_firmware:
     runs-on: ubuntu-latest
-    container: microros/base:${{github.base_ref}}
+    container: microros/ci:${{github.base_ref}}
     needs: micro_ros_build
 
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,8 @@ jobs:
           - rtos: freertos
             platform: olimex-stm32-e407
             configuration: serial
-            files: 'firmware/olimex_e407_extensions/build/micro-ROS.bin'
+            files: 'firmware/olimex_e407_extensions/build/micro-ROS.elf,
+                    firmware/olimex_e407_extensions/build/micro-ROS.bin'
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,9 @@ jobs:
 
   micro_ros_build:
     runs-on: ubuntu-latest
-    container: microros/base:${{github.base_ref}}
-
+    #container: microros/base:${{github.base_ref}}
+    container: microros/base:dashing
+      
     steps:
     - uses: actions/checkout@v2
       with:
@@ -39,7 +40,8 @@ jobs:
 
   agent:
     runs-on: ubuntu-latest
-    container: microros/base:${{github.base_ref}}
+    #container: microros/base:${{github.base_ref}}
+    container: microros/base:dashing
     needs: micro_ros_build
 
     steps:
@@ -74,7 +76,8 @@ jobs:
 
   client_host:
     runs-on: ubuntu-latest
-    container: microros/base:${{github.base_ref}}
+    #container: microros/base:${{github.base_ref}}
+    container: microros/base:dashing
     needs: micro_ros_build
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
       # TODO: By now skip the RCLC packages, due to compilation errors on the CI docker.
       - name: Create ws and build
         run: |
-          . /opt/ros/$ROS_DISTRO/setup.sh
+          . /opt/ros/dashing/setup.sh
           . install/local_setup.sh
           apt-get update
           ros2 run micro_ros_setup create_host_client_ws.sh
@@ -125,7 +125,8 @@ jobs:
           
   client_firmware:
     runs-on: ubuntu-latest
-    container: microros/ci:${{github.base_ref}}
+    #container: microros/ci:${{github.base_ref}}
+    container: microros/ci:dashing
     needs: micro_ros_build
 
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,9 +102,8 @@ jobs:
         run: |
           . /opt/ros/$ROS_DISTRO/setup.sh
           . install/local_setup.sh
-          apt-get update
           ros2 run micro_ros_setup create_host_client_ws.sh
-          colcon build --merge-install --metas src --packages-skip rclc micro_ros_demos_rclc rclc_examples
+          colcon build --merge-install --metas src
 
   client_firmware:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,10 +76,9 @@ jobs:
 
   client_host:
     runs-on: ubuntu-latest
-    #container: microros/base:${{github.base_ref}}
     container: microros/base:dashing
     needs: micro_ros_build
-
+    
     steps:
       - uses: actions/checkout@v2
         with:
@@ -98,9 +97,8 @@ jobs:
       - run: |
           chmod +x -R install/lib/micro_ros_setup
           chmod +x install/config/host/generic/*.sh
-
-      # TODO: By now skip the RCLC packages, due to compilation errors on the CI docker.
-      - name: Create ws and build
+          
+      - name: Source required files
         run: |
           . /opt/ros/dashing/setup.sh
           . install/local_setup.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,7 @@ name: CI
 on:
   pull_request:
     branches:
-    - dashing
-    - crystal
+    - improve_ci
 
 jobs:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,23 +102,9 @@ jobs:
         run: |
           . /opt/ros/$ROS_DISTRO/setup.sh
           . install/local_setup.sh
+          apt-get update
           ros2 run micro_ros_setup create_host_client_ws.sh
           colcon build --merge-install --metas src --packages-skip rclc micro_ros_demos_rclc rclc_examples
-
-      # Check if the files exist
-      #- name: Test file installation
-      #  run: |
-      #    (test -f install/lib/micro_ros_demos_rcl/int32_publisher/int32_publisher  && true) || false
-      #    (test -f install/lib/micro_ros_demos_rcl/int32_subscriber/int32_subscriber  && true) || false
-      #    (test -f install/lib/micro_ros_demos_rcl/int32_publisher_subscriber/int32_publisher_subscriber  && true) || false
-      #    (test -f install/lib/micro_ros_demos_rcl/int32_multinode/int32_multinode  && true) || false
-      #    (test -f install/lib/micro_ros_demos_rcl/guard_condition/guard_condition  && true) || false
-      #    (test -f install/lib/micro_ros_demos_rcl/fibonacci_action_server/fibonacci_action_server  && true) || false
-      #    (test -f install/lib/micro_ros_demos_rcl/fibonacci_action_client/fibonacci_action_client  && true) || false
-      #    (test -f install/lib/micro_ros_demos_rcl/configured_subscriber/configured_subscriber  && true) || false
-      #    (test -f install/lib/micro_ros_demos_rcl/configured_publisher/configured_publisher  && true) || false
-      #    (test -f install/lib/micro_ros_demos_rcl/addtwoints_server/addtwoints_server  && true) || false
-      #    (test -f install/lib/micro_ros_demos_rcl/addtwoints_client/addtwoints_client  && true) || false
 
   client_firmware:
     runs-on: ubuntu-latest
@@ -152,7 +138,6 @@ jobs:
             configuration: serial
             files: 'firmware/olimex_e407_extensions/build/micro-ROS.elf,
                     firmware/olimex_e407_extensions/build/micro-ROS.bin'
-
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
       fail-fast: false
       matrix:
         rtos: [nuttx, freertos]
-        platform: [crazyflie21, generic]
+        platform: [crazyflie21, generic, olimex-stm32-e407]
         exclude:
           - rtos: freertos
             platform: generic
@@ -147,8 +147,17 @@ jobs:
             platform: generic
             configuration: olimex-stm32-e407/uros
             files: 'firmware/NuttX/nuttx'
+          - rtos: nuttx
+            platform: olimex-stm32-e407
+            configuration: uros
+            files: 'firmware/NuttX/nuttx'
           - rtos: freertos
+            platform: crazyflie21
             files: 'firmware/crazyflie_microros_extensions/cf2.elf'
+          - rtos: freertos
+            platform: olimex-stm32-e407
+            files: 'firmware/olimex_e407_extensions/build/micro-ROS.elf,
+                    firmware/olimex_e407_extensions/build/micro-ROS.bin'
 
     steps:
       - uses: actions/checkout@v2

--- a/micro_ros_setup/config/freertos/crazyflie21/build.sh
+++ b/micro_ros_setup/config/freertos/crazyflie21/build.sh
@@ -1,3 +1,5 @@
+set +o nounset
+
 CF_DIR=$FW_TARGETDIR/crazyflie_firmware
 CF_EXTENSIONS_DIR=$FW_TARGETDIR/crazyflie_microros_extensions
 

--- a/micro_ros_setup/config/freertos/crazyflie21/build.sh
+++ b/micro_ros_setup/config/freertos/crazyflie21/build.sh
@@ -19,5 +19,5 @@ pushd $CF_EXTENSIONS_DIR >/dev/null
         make libmicroros $EXTRA
     fi
     # build crayflie firmware
-    make PLATFORM=cf2 CLOAD=0
+    make PLATFORM=cf2 CLOAD=0 $EXTRA
 popd >/dev/null

--- a/micro_ros_setup/config/freertos/crazyflie21/build.sh
+++ b/micro_ros_setup/config/freertos/crazyflie21/build.sh
@@ -7,15 +7,17 @@ pushd $CF_DIR >/dev/null
 popd >/dev/null
 
 pushd $CF_EXTENSIONS_DIR >/dev/null
+
+    if [[ -v UROS_EXTERNAL_DEPS ]]; then
+        echo "Using external deps: $UROS_EXTERNAL_DEPS"
+        EXTRA="CROSS_COMPILE=$UROS_EXTERNAL_DEPS"
+    fi
+
     if [ "$UROS_FAST_BUILD" = "off" ] || [ ! -d "bin" ]; then
         # clean build
         make clean
 
         # build micro-ROS stack
-        if [[ -v UROS_EXTERNAL_DEPS ]]; then
-            echo "Using external deps: $UROS_EXTERNAL_DEPS"
-            EXTRA="CROSS_COMPILE=$UROS_EXTERNAL_DEPS"
-        fi
         make libmicroros $EXTRA
     fi
     # build crayflie firmware

--- a/micro_ros_setup/config/freertos/crazyflie21/build.sh
+++ b/micro_ros_setup/config/freertos/crazyflie21/build.sh
@@ -12,7 +12,11 @@ pushd $CF_EXTENSIONS_DIR >/dev/null
         make clean
 
         # build micro-ROS stack
-        make libmicroros
+        if [[ -v UROS_EXTERNAL_DEPS ]]; then
+            echo "Using external deps: $UROS_EXTERNAL_DEPS"
+            EXTRA="CROSS_COMPILE=$UROS_EXTERNAL_DEPS"
+        fi
+        make libmicroros $EXTRA
     fi
     # build crayflie firmware
     make PLATFORM=cf2 CLOAD=0

--- a/micro_ros_setup/config/freertos/crazyflie21/crazyflie.repos
+++ b/micro_ros_setup/config/freertos/crazyflie21/crazyflie.repos
@@ -7,7 +7,3 @@ repositories:
   crazyflie_microros_extensions:
     type: git
     url: https://github.com/micro-ROS/crazyflie_extensions
-    version: feature/external_toolchain
-
-
-

--- a/micro_ros_setup/config/freertos/crazyflie21/crazyflie.repos
+++ b/micro_ros_setup/config/freertos/crazyflie21/crazyflie.repos
@@ -7,6 +7,7 @@ repositories:
   crazyflie_microros_extensions:
     type: git
     url: https://github.com/micro-ROS/crazyflie_extensions
+    version: feature/external_toolchain
 
 
 

--- a/micro_ros_setup/config/freertos/crazyflie21/create.sh
+++ b/micro_ros_setup/config/freertos/crazyflie21/create.sh
@@ -1,12 +1,15 @@
 pushd $FW_TARGETDIR >/dev/null
-    # Install toolchain
-    mkdir toolchain
-    
-    echo "Downloading ARM compiler, this may take a while"
-    curl -fsSLO https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2019q3/RC1.1/gcc-arm-none-eabi-8-2019-q3-update-linux.tar.bz2 
-    tar --strip-components=1 -xvjf gcc-arm-none-eabi-8-2019-q3-update-linux.tar.bz2 -C toolchain  > /dev/null
-    rm gcc-arm-none-eabi-8-2019-q3-update-linux.tar.bz2
-    
+
+    if [[ ! -v GITHUB_ACTIONS ]]; then
+        # Install toolchain
+        mkdir toolchain
+
+        echo "Downloading ARM compiler, this may take a while"
+        curl -fsSLO https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2019q3/RC1.1/gcc-arm-none-eabi-8-2019-q3-update-linux.tar.bz2
+        tar --strip-components=1 -xvjf gcc-arm-none-eabi-8-2019-q3-update-linux.tar.bz2 -C toolchain  > /dev/null
+        rm gcc-arm-none-eabi-8-2019-q3-update-linux.tar.bz2
+    fi
+
     # Import repos
     vcs import --input $PREFIX/config/$RTOS/$PLATFORM/crazyflie.repos >/dev/null
 

--- a/micro_ros_setup/config/freertos/olimex-stm32-e407/build.sh
+++ b/micro_ros_setup/config/freertos/olimex-stm32-e407/build.sh
@@ -1,14 +1,19 @@
 OLIMEX_EXTENSIONS_DIR=$FW_TARGETDIR/olimex_e407_extensions
 
 pushd $OLIMEX_EXTENSIONS_DIR >/dev/null
+    if [[ -v UROS_EXTERNAL_DEPS ]]; then
+        echo "Using external deps: $UROS_EXTERNAL_DEPS"
+        EXTRA="CROSS_COMPILE=$UROS_EXTERNAL_DEPS"
+    fi
+
     if [ "$UROS_FAST_BUILD" = "off" ] || [ ! -d "build" ]; then
         # clean build
         make clean
 
         # build micro-ROS stack
-        make libmicroros
+        make libmicroros $EXTRA
     fi
 
     # build firmware
-    make
+    make $EXTRA
 popd >/dev/null

--- a/micro_ros_setup/config/freertos/olimex-stm32-e407/build.sh
+++ b/micro_ros_setup/config/freertos/olimex-stm32-e407/build.sh
@@ -1,3 +1,5 @@
+set +o nounset
+
 OLIMEX_EXTENSIONS_DIR=$FW_TARGETDIR/olimex_e407_extensions
 
 pushd $OLIMEX_EXTENSIONS_DIR >/dev/null

--- a/micro_ros_setup/config/freertos/olimex-stm32-e407/create.sh
+++ b/micro_ros_setup/config/freertos/olimex-stm32-e407/create.sh
@@ -1,12 +1,15 @@
 pushd $FW_TARGETDIR >/dev/null
-    # Install toolchain
-    mkdir toolchain
-    
-    echo "Downloading ARM compiler, this may take a while"
-    curl -fsSLO https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2019q3/RC1.1/gcc-arm-none-eabi-8-2019-q3-update-linux.tar.bz2 
-    tar --strip-components=1 -xvjf gcc-arm-none-eabi-8-2019-q3-update-linux.tar.bz2 -C toolchain  > /dev/null
-    rm gcc-arm-none-eabi-8-2019-q3-update-linux.tar.bz2
-    
+
+    if [[ ! -v GITHUB_ACTIONS ]]; then
+        # Install toolchain
+        mkdir toolchain
+
+        echo "Downloading ARM compiler, this may take a while"
+        curl -fsSLO https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2019q3/RC1.1/gcc-arm-none-eabi-8-2019-q3-update-linux.tar.bz2
+        tar --strip-components=1 -xvjf gcc-arm-none-eabi-8-2019-q3-update-linux.tar.bz2 -C toolchain  > /dev/null
+        rm gcc-arm-none-eabi-8-2019-q3-update-linux.tar.bz2
+    fi
+
     # Import repos
     vcs import --input $PREFIX/config/$RTOS/$PLATFORM/olimex_e407.repos >/dev/null
 

--- a/micro_ros_setup/config/freertos/olimex-stm32-e407/olimex_e407.repos
+++ b/micro_ros_setup/config/freertos/olimex-stm32-e407/olimex_e407.repos
@@ -2,4 +2,4 @@ repositories:
   olimex_e407_extensions:
     type: git
     url: https://github.com/micro-ROS/olimex_e407_extensions
-    version: feature/expose_cross_compile
+    version: master

--- a/micro_ros_setup/config/freertos/olimex-stm32-e407/olimex_e407.repos
+++ b/micro_ros_setup/config/freertos/olimex-stm32-e407/olimex_e407.repos
@@ -2,6 +2,4 @@ repositories:
   olimex_e407_extensions:
     type: git
     url: https://github.com/micro-ROS/olimex_e407_extensions
-
-
-
+    version: feature/expose_cross_compile


### PR DESCRIPTION
Uses a new base image: `microros/ci:dashing` to build firmware clients.
This base image has the toolchains pre-downloaded it should avoid the spurious download error.