### PR TITLE
Update zephyr Flash to Olimex support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,19 +200,19 @@ jobs:
 
           - rtos: freertos
             platform: olimex-stm32-e407
-            configuration: olimex_ping_pong
+            configuration: int32_publisher
             transport_arguments: -t serial -d /dev/ttyS0
             binary: 'firmware/freertos_apps/microros_olimex_e407_extensions/build/micro-ROS.elf'
 
           - rtos: zephyr
             platform: olimex-stm32-e407
-            configuration: sample_publisher
+            configuration: int32_publisher
             transport_arguments: -t serial-usb
             binary: 'firmware/build/zephyr/zephyr.bin'
 
           - rtos: zephyr
             platform: discovery_l475_iot1
-            configuration: sample_publisher
+            configuration: int32_publisher
             transport_arguments: -t serial-usb
             binary: 'firmware/build/zephyr/zephyr.bin'
 

--- a/micro_ros_setup/config/freertos/crazyflie21/client_uros_packages.repos
+++ b/micro_ros_setup/config/freertos/crazyflie21/client_uros_packages.repos
@@ -21,7 +21,7 @@ repositories:
   uros/rmw_microxrcedds:
     type: git
     url: https://github.com/micro-ROS/rmw-microxrcedds.git
-    version: feature/xrce_session_management
+    version: feature/qos
   uros/rosidl_typesupport_microxrcedds:
     type: git
     url: https://github.com/micro-ROS/rosidl_typesupport_microxrcedds.git

--- a/micro_ros_setup/config/freertos/olimex-stm32-e407/client_uros_packages.repos
+++ b/micro_ros_setup/config/freertos/olimex-stm32-e407/client_uros_packages.repos
@@ -21,7 +21,7 @@ repositories:
   uros/rmw_microxrcedds:
     type: git
     url: https://github.com/micro-ROS/rmw-microxrcedds.git
-    version: feature/custom_serial_selection
+    version: feature/qos
   uros/rosidl_typesupport_microxrcedds:
     type: git
     url: https://github.com/micro-ROS/rosidl_typesupport_microxrcedds.git

--- a/micro_ros_setup/config/zephyr/generic/flash.sh
+++ b/micro_ros_setup/config/zephyr/generic/flash.sh
@@ -1,5 +1,6 @@
 pushd $FW_TARGETDIR > /dev/null
 
+if [ "$PLATFORM" = "discovery_l475_iot1" ]; then
   export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
   export ZEPHYR_SDK_INSTALL_DIR=$FW_TARGETDIR/zephyr-sdk
 
@@ -8,6 +9,29 @@ pushd $FW_TARGETDIR > /dev/null
   export PATH=~/.local/bin:"$PATH"
 
   west flash
+elif [ "$PLATFORM" = "olimex-stm32-e407" ]; then
+  if [ -f build/zephyr/zephyr.bin ]; then
+    echo "Flashing firmware for $RTOS platform $PLATFORM"
+
+      if lsusb -d 15BA:002a; then
+        PROGRAMMER=interface/ftdi/olimex-arm-usb-tiny-h.cfg
+      elif lsusb -d 15BA:0003;then
+        PROGRAMMER=interface/ftdi/olimex-arm-usb-ocd.cfg
+      elif lsusb -d 15BA:002b;then
+        PROGRAMMER=interface/ftdi/olimex-arm-usb-ocd-h.cfg
+      else
+        echo "Error. Unsuported OpenOCD USB programmer"
+        exit 1
+      fi
+
+      openocd -f $PROGRAMMER -f target/stm32f4x.cfg -c init -c "reset halt" -c "flash write_image erase build/zephyr/zephyr.bin 0x08000000" -c "reset" -c "exit"
+  else
+    echo "build/zephyr/zephyr.bin not found: please compile before flashing."
+  fi
+else
+  echo "Unrecognized board: $PLATFORM"
+  exit 1
+fi
 
 popd > /dev/null
 


### PR DESCRIPTION
This PR refactors the flash script in order to use the Olimex ARM-USB-Tiny JTAG adapter