### PR TITLE
Zephyr Cmake install fix

### DIFF
--- a/micro_ros_setup/config/host/generic/client-host-colcon.meta
+++ b/micro_ros_setup/config/host/generic/client-host-colcon.meta
@@ -28,11 +28,13 @@
         "rmw_microxrcedds":{
             "cmake-args":[
                 "-DRMW_UXRCE_TRANSPORT=udp",
-                "-DRMW_UXRCE_MAX_NODES=1",
-                "-DRMW_UXRCE_MAX_PUBLISHERS_X_NODE=2",
-                "-DRMW_UXRCE_MAX_SUBSCRIPTIONS_X_NODE=1",
-                "-DRMW_UXRCE_MAX_SERVICES_X_NODE=5",
-                "-DRMW_UXRCE_MAX_CLIENTS_X_NODE=5",
+                "-DRMW_UXRCE_DEFAULT_UDP_IP=127.0.0.1",
+                "-DRMW_UXRCE_DEFAULT_UDP_PORT=8888",
+                "-DRMW_UXRCE_MAX_NODES=3",
+                "-DRMW_UXRCE_MAX_PUBLISHERS=5",
+                "-DRMW_UXRCE_MAX_SUBSCRIPTIONS=5",
+                "-DRMW_UXRCE_MAX_SERVICES=5",
+                "-DRMW_UXRCE_MAX_CLIENTS=5",
                 "-DRMW_UXRCE_MAX_HISTORY=10",
                 "-DRMW_UXRCE_XML_BUFFER_LENGTH=1000"
             ]

--- a/micro_ros_setup/config/zephyr/generic/create.sh
+++ b/micro_ros_setup/config/zephyr/generic/create.sh
@@ -2,11 +2,14 @@
 
 # We need a version newer than the repo
 wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | sudo apt-key add -
-# sudo echo "deb https://apt.kitware.com/ubuntu/ bionic main" > /etc/apt/sources.list.d/kitware.list
-sudo apt install software-properties-common
-sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
-sudo apt update
-sudo apt install cmake -y
+if sudo echo "deb https://apt.kitware.com/ubuntu/ bionic main" > /etc/apt/sources.list.d/kitware.list; then
+    sudo apt update
+    sudo apt install cmake -y
+else
+    echo "Error while installing CMake version >= 3.13.1"
+    echo "Please if not installed follow the instructions: https://docs.zephyrproject.org/latest/getting_started/index.html"
+    sleep 2
+fi
 
 export PATH=~/.local/bin:"$PATH"
 

--- a/micro_ros_setup/config/zephyr/generic/create.sh
+++ b/micro_ros_setup/config/zephyr/generic/create.sh
@@ -6,7 +6,7 @@ if sudo echo "deb https://apt.kitware.com/ubuntu/ bionic main" > /etc/apt/source
     sudo apt update
     sudo apt install cmake -y
 else
-    echo "Error while installing CMake version >= 3.13.1"
+    echo "Error while installing CMake version >= 3.13.1. Check with cmake --version"
     echo "Please if not installed follow the instructions: https://docs.zephyrproject.org/latest/getting_started/index.html"
     sleep 2
 fi

--- a/micro_ros_setup/config/zephyr/generic/create.sh
+++ b/micro_ros_setup/config/zephyr/generic/create.sh
@@ -2,7 +2,9 @@
 
 # We need a version newer than the repo
 wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | sudo apt-key add -
-sudo echo "deb https://apt.kitware.com/ubuntu/ bionic main" > /etc/apt/sources.list.d/kitware.list
+# sudo echo "deb https://apt.kitware.com/ubuntu/ bionic main" > /etc/apt/sources.list.d/kitware.list
+sudo apt install software-properties-common
+sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
 sudo apt update
 sudo apt install cmake -y
 


### PR DESCRIPTION
This PR manages the errors while upgrading CMake version in Zephyr and ask the user to install it manually in the case it can't install it