### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: dependencies
         run: |
           apt update
-          apt install -y python3-colcon-metadata
+          apt install -y python3-colcon-metadata python3-pip
           rosdep update
           rosdep install -y --from-paths src --ignore-src -y
 
@@ -51,7 +51,7 @@ jobs:
       - name: dependencies
         run: |
           apt update
-          apt install -y python3-colcon-metadata
+          apt install -y python3-colcon-metadata python3-pip
           rosdep update
           rosdep install -y --from-paths src --ignore-src -y
 
@@ -88,7 +88,7 @@ jobs:
       - name: dependencies
         run: |
           apt update
-          apt install -y python3-colcon-metadata
+          apt install -y python3-colcon-metadata python3-pip
           rosdep update
           rosdep install -y --from-paths src --ignore-src -y
 
@@ -138,7 +138,7 @@ jobs:
       - name: dependencies
         run: |
           apt update
-          apt install -y python3-colcon-metadata
+          apt install -y python3-colcon-metadata python3-pip
           rosdep update
           rosdep install -y --from-paths src --ignore-src -y
 
@@ -222,7 +222,7 @@ jobs:
       - name: dependencies
         run: |
           apt update
-          apt install -y python3-colcon-metadata
+          apt install -y python3-colcon-metadata python3-pip
           rosdep update
           rosdep install -y --from-paths src --ignore-src -y
 


### PR DESCRIPTION
This PR adds Python3 pip to the CI (failing on Zephyr)

This PR fixes the CI failing here: https://github.com/micro-ROS/micro-ros-build/pull/113