### PR TITLE
Relax Zephyr build for more platforms

### DIFF
--- a/micro_ros_setup/config/zephyr/generic/build.sh
+++ b/micro_ros_setup/config/zephyr/generic/build.sh
@@ -39,8 +39,8 @@ pushd $FW_TARGETDIR >/dev/null
     elif [ "$PLATFORM" = "host" ]; then
         export BOARD="native_posix"
     else
-        echo "Unrecognized board: $PLATFORM"
-        exit 1
+        echo "Unrecognized board: $PLATFORM, Trying to build"
+        export BOARD=$PLATFORM
     fi
 
     # Use transport specific conf if given and exists.

--- a/micro_ros_setup/config/zephyr/generic/build.sh
+++ b/micro_ros_setup/config/zephyr/generic/build.sh
@@ -39,7 +39,7 @@ pushd $FW_TARGETDIR >/dev/null
     elif [ "$PLATFORM" = "host" ]; then
         export BOARD="native_posix"
     else
-        echo "Unrecognized board: $PLATFORM, Trying to build"
+        echo "Unrecognized board: $PLATFORM. Trying to build"
         export BOARD=$PLATFORM
     fi
 


### PR DESCRIPTION
This PR relax the Zephyr build script for allowing building not supported platforms